### PR TITLE
Auto-merge dependabot updates

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,8 @@
+---
+- match:
+    dependency_name: "pytest-homeassistant-custom-component"
+    dependency_type: "all"
+    update_type: "all"
+- match:
+    dependency_type: "production"
+    update_type: "semver:minor"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,15 @@
+---
+name: "Automatically Merge Certain Depedency Updates"
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: "ahmadnassri/action-dependabot-auto-merge@v2"
+        with:
+          target: "minor"
+          github-token: ${{ secrets.AUTO_MERGE_TOKEN }}


### PR DESCRIPTION
* Always auto-merge for pytest-homeassistant-custom-component.
* Auto-merge minor updates for everything else.

Note: this will only auto-merge if CI passes.