### PR TITLE
Fix name of job for auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,5 +1,5 @@
 ---
-name: "Automatically Merge Certain Depedency Updates"
+name: "auto-merge"
 
 on:
   pull_request:


### PR DESCRIPTION
It apparently needs to be specifically `auto-merge`, otherwise it fails.
See https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/120