### PR TITLE
Add support for connecting to a MQTT broker secured by TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ The configuration file supports `!secret` strings, [as documented for Home Assis
 | password       | str                 | None                          | Any str                               | The password to use to connect to the MQTT broker.                                                            |
 | port           | int                 | 1883                          | Any int                               | The port to connect to the broker on.                                                                         |
 | qos            | int                 | 0                             | 0-2                                   | The qos to use for messages sent to the MQTT broker.                                                          |
+| tls_options    | dict                | `{}`                          | See [tls options](#tls-options)       | TLS Options to use when connecting to the MQTT broker. Only used when `usetls` is True.                       |
 | topic_prefix   | Jina2 template str  | brultech-serial2mqtt-{serial} | Any Jinja2 template str               | The root topic to publish status messages on. `device_serial` is available to use in the template.            |
 | username       | str                 | None                          | Any str                               | The username to connect to use to connect to the MQTT broker.                                                 |
+| usetls         | bool                | False                         | Any bool                              | Use TLS when connecting to the MQTT broker.                                                                   |
 | will_message   | dict                | `{}`                          | See [will message](#will-message)     | The will message to send when we disconnect from the MQTT broker.                                             |
 
 ### Birth Message
@@ -170,6 +172,20 @@ The birth message is sent under the topic prefix configured in the [MQTT](#mqtt)
 | payload | str  | online               | Any str           | The payload Home Assistant is configured to use when sending the birth message. |
 | qos     | int  | 0                    | 0-2               | The qos Home Assistant is configured to use for the birth message.              |
 | topic   | str  | homeassistant/status | Any str           | The topic Home Assistant is configured to use when sending the birth message.   |
+
+### TLS Options
+
+Corresponds directly to asyncio-mqtt's [TLSParameters](https://github.com/sbtinstruments/asyncio-mqtt#tls).
+
+| Name             | Type | Default              | Supported Options          | Description                                                                                               |
+| ---------------- | ---- | -------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------- |
+| ca_certs         | str  | None                 | Any str                    | Path to CA certificate files to be trusted by this client.                                                |
+| certfile         | str  | None                 | Any str                    | Path to a PEM encoded client certificate file.                                                            |
+| keyfile          | str  | None                 | Any str                    | Path to a PEM encoded private key file.                                                                   |
+| keyfile_password | str  | None                 | Any str                    | Password to decrypt either `certfile` or `keyfile` (if encrypted).                                        |
+| cert_reqs        | bool | True                 | Any bool                   | Enforce certificate requirements. Set to False to connect to, e.g., self-signed hosts.                    |
+| ciphers          | str  | None                 | Any str                    | Allowable encryption ciphers for this connection (set to None to use the defaults).                       |
+| tls_version      | str  | tls1.2               | None, tls1, tls1.1, tls1.2 | Version of the SSL/TLS protocol to use.                                                                   |
 
 ### Will Message
 

--- a/brultech_serial2mqtt/__init__.py
+++ b/brultech_serial2mqtt/__init__.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from aiobrultech_serial import Connection as DeviceConnection
 from asyncio_mqtt import Client as MQTTClient
+from asyncio_mqtt import TLSParameters as MqttTlsParams
 from asyncio_mqtt.client import Will
 from asyncio_mqtt.error import MqttError
 from siobrultech_protocols.gem.packets import PacketFormatType as DevicePacketFormatType
@@ -66,6 +67,17 @@ class BrultechSerial2MQTT:
                         password=self._config.mqtt.password,
                         port=self._config.mqtt.port,
                         username=self._config.mqtt.username,
+                        tls_params=MqttTlsParams(
+                            ca_certs=self._config.mqtt.tls_options.ca_certs,
+                            cert_reqs=self._config.mqtt.tls_options.cert_reqs,
+                            certfile=self._config.mqtt.tls_options.certfile,
+                            ciphers=self._config.mqtt.tls_options.ciphers,
+                            keyfile=self._config.mqtt.tls_options.keyfile,
+                            keyfile_password=self._config.mqtt.tls_options.keyfile_password,
+                            tls_version=self._config.mqtt.tls_options.tls_version,
+                        )
+                        if self._config.mqtt.usetls
+                        else None,
                         will=Will(
                             payload=self._config.mqtt.will_message.payload,
                             qos=self._config.mqtt.will_message.qos,

--- a/brultech_serial2mqtt/config/config_mqtt.py
+++ b/brultech_serial2mqtt/config/config_mqtt.py
@@ -161,7 +161,7 @@ class TlsConfig:
         return self._ca_certs
 
     @property
-    def cert_reqs(self):
+    def cert_reqs(self) -> ssl.VerifyMode:
         if not self._cert_reqs:
             return ssl.CERT_NONE
         else:
@@ -184,7 +184,7 @@ class TlsConfig:
         return self._keyfile_password
 
     @property
-    def tls_version(self):
+    def tls_version(self) -> Optional[int]:
         if self._tls_version == "tls1":
             return ssl.PROTOCOL_TLSv1
         elif self._tls_version == "tls1.1":

--- a/brultech_serial2mqtt/config/config_mqtt.py
+++ b/brultech_serial2mqtt/config/config_mqtt.py
@@ -191,9 +191,8 @@ class TlsConfig:
             return ssl.PROTOCOL_TLSv1_1
         elif self._tls_version == "tls1.2":
             return ssl.PROTOCOL_TLSv1_2
-        elif self._tls_version is None:
-            return None
         else:
+            # Let paho-mqtt handle (defaults to ssl.PROTOCOL_TLS)
             return None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ python_requires = >=3.8, <4
 packages = find:
 install_requires = 
 	aiobrultech-serial == 0.5.0
-	asyncio-mqtt == 0.12.1
+	asyncio-mqtt == 0.13.0
 	jinja2 >= 3.0, < 4
 	pyserial == 3.5
 	pyyaml == 6.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,6 +54,7 @@ class TestSimpleConfig(unittest.TestCase):
         )
         self.assertEqual(config.mqtt.topic_prefix(123), "brultech-serial2mqtt-123")
         self.assertIsNone(config.mqtt.username)
+        self.assertEqual(config.mqtt.usetls, False)
         self.assertEqual(config.mqtt.birth_message.payload, "online")
         self.assertEqual(config.mqtt.birth_message.qos, 0)
         self.assertTrue(config.mqtt.birth_message.retain)


### PR DESCRIPTION
Adds two new options to the MQTT config to support brokers secured by TLS. The first option, `usetls`, controls whether the MQTT client should attempt a TLS connection. The second option, `tls_options` is a dict representing all the TLS options available in asyncio-mqtt's `TLSParameters` class. `tls_options` is only used if `usetls` is set to `true`.

Tested against secured and unsecured brokers.