### PR TITLE
Fix `DeprecationWarning` for `asyncio.get_event_loop`

### DIFF
--- a/brultech_serial2mqtt/__main__.py
+++ b/brultech_serial2mqtt/__main__.py
@@ -4,5 +4,7 @@ from brultech_serial2mqtt import BrultechSerial2MQTT
 
 if __name__ == "__main__":
     bs2m = BrultechSerial2MQTT()
-    asyncio.get_event_loop().run_until_complete(bs2m.start())
-    asyncio.get_event_loop().run_forever()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(bs2m.start())
+    loop.run_forever()


### PR DESCRIPTION
In Python 3.11, calling `asyncio.get_event_loop` will be an error, and in Python 3.10, we get the following warning:
```
/src/brultech_serial2mqtt/brultech_serial2mqtt/__main__.py:7: DeprecationWarning: There is no current event loop
  asyncio.get_event_loop().run_until_complete(bs2m.start())
```

This change fixes this by explicetly creating an event loop.