### PR TITLE
Bring down the container for non-zero exit codes

### DIFF
--- a/docker/root/etc/services.d/brultech-serial2mqtt/finish
+++ b/docker/root/etc/services.d/brultech-serial2mqtt/finish
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/execlineb -S1
 
-exec \
-    s6-svscanctl -t /var/run/s6/services
+if { s6-test ${1} -ne 0 -a ${1} -ne 256 }
+/run/s6/basedir/bin/halt


### PR DESCRIPTION
If there is an error, the container is meant to be brought down (and therefore monitoring can pick up that there's an issue).  However, the current code does not work and gets the following error:
```
s6-svscanctl: fatal: unable to control /var/run/s6/services: supervisor not listening
```

Looking over the
[documentation](https://github.com/just-containers/s6-overlay#writing-an-optional-finish-script), we should instead do something like this change.  This still allows the service to gracefully restart when there is an MQTT connection issue, as done in eb71b23c00d7ba0150f5a9d5a9f3a8b4933f7f5e via #28.